### PR TITLE
Allow headers in get from json

### DIFF
--- a/examples/simple_ua.pl
+++ b/examples/simple_ua.pl
@@ -4,7 +4,10 @@ use LWP::UserAgent::Caching::Simple qw/get_from_json/;
 
 # $HTTP::Caching::DEBUG = 1;
 
-my $data = get_from_json(shift);
+my $data = get_from_json(shift,
+    'Cache-Control' => 'max-stale=3600',
+    'Cache-Control' => 'no-transform'
+);
 
 use Data::Dumper;
 print Dumper $data;

--- a/lib/LWP/UserAgent/Caching/Simple.pm
+++ b/lib/LWP/UserAgent/Caching/Simple.pm
@@ -78,11 +78,7 @@ sub new {
 }
 
 sub get_from_json {
-    my $rqst = HTTP::Request->new(
-        GET => $_[0],
-        [ Accept => 'application/json' ]
-    );
-    my $resp = _default_useragent()->request($rqst);
+    my $resp = _default_useragent()->get(@_, Accept => 'application/json');
     return decode_json($resp->decoded_content()) if $resp->is_success;
     warn "HTTP Status message ${\$resp->code} [${\$resp->message}] GET $_[0]\n";
     return

--- a/lib/LWP/UserAgent/Caching/Simple.pm
+++ b/lib/LWP/UserAgent/Caching/Simple.pm
@@ -38,7 +38,11 @@ and maybe even something quick:
     
     use LWP::UserAgent::Caching::Simple qw(get_from_json);
     
-    my $hashref = get_from_json ( 'http://example.com/cached?' );
+    my $hashref = get_from_json (
+        'http://example.com/cached?',
+        'Cache-Control' => 'max-stale',    # without delta-seconds, unlimited
+        'Cache-Control' => 'no-transform', # something not implemented
+    );
 
 
 =head1 DESCRIPTION
@@ -104,17 +108,13 @@ the following object methods:
 
 =back
 
-And to make life realy simple, when imported, one function
+=head1 EXPORT_OK
 
-=over
+=head2 get_from_json
 
-=item get_from_json
-
-this will simply make a GET request to a server, with the C<Accept> Header set
+This will simply make a GET request to a server, with the C<Accept> Header set
 to C<application/json>. On succes, it will turn the returned json (as requested)
 into a perl data structure. Otherwise it will be C<undef> and print a warning.
-
-=back
 
 =head1 CAVEATS
 


### PR DESCRIPTION
This change allows to pass in arbitrary headers. This is very useful to set `Cache-Control` headers, to ... control the cache